### PR TITLE
Allow empty strings in translations sentences

### DIFF
--- a/Leaflet.i18n.js
+++ b/Leaflet.i18n.js
@@ -25,7 +25,7 @@
         L.locale = code;
     };
     return L.i18n = L._ = function translate(string, data) {
-        if (L.locale && L.locales[L.locale] && L.locales[L.locale][string]) {
+        if (L.locale && L.locales[L.locale] && typeof L.locales[L.locale][string] !== "undefined") {
             string = L.locales[L.locale][string];
         }
         try {

--- a/spec/specs.js
+++ b/spec/specs.js
@@ -2,7 +2,8 @@ describe('L.i18n', function(){
     beforeEach(function(){
         var fr = {
             "Simple phrase to translate": "Une simple phrase à traduire",
-            "A phrase with a {variable} to translate": "Une phrase à traduire avec une {variable}"
+            "A phrase with a {variable} to translate": "Une phrase à traduire avec une {variable}",
+            "A phrase with empty translation": ""
         };
         L.registerLocale('fr', fr);
         L.setLocale('fr');
@@ -26,6 +27,10 @@ describe('L.i18n', function(){
 
     it("should translate sentences with a variable", function() {
         expect(L._("A phrase with a {variable} to translate", {variable: "foo"})).to.eql("Une phrase à traduire avec une foo");
+    });
+
+    it("should translate empty translations", function() {
+        expect(L._("A phrase with empty translation")).to.eql("");
     });
 
     it("should not fail if a variable is missing", function() {


### PR DESCRIPTION
### Steps to reproduce:

```js
var fr = {
  "Simple phrase to translate": "Une simple phrase à traduire",
  "A phrase with a {variable} to translate": "Une phrase à traduire avec une {variable}",
  "A phrase with empty translation": ""
};

L.registerLocale('fr', fr);
L.setLocale('fr');
```

###  Current behavior:

```js
L._("A phrase with empty translation"); // --> "A phrase with empty translation"
```

###  Expected behavior:

```js
L._("A phrase with empty translation"); // --> ""
```

_Have a nice day,
Raruto_